### PR TITLE
feat: set additional properties to false when unknown option is raise

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -87,3 +87,4 @@ Contributors (chronological)
 - Robert Shepley `@ShepleySound <https://github.com/ShepleySound>`_
 - Robin `@allrob23 <https://github.com/allrob23>`_
 - Xingang Zhang `@0x0400 <https://github.com/0x0400>`_
+- Pieter `@pieterocp <https://github.com/pieterocp>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+(unreleased)
+************
+
+Features:
+
+- ``MarshmallowPlugin`` now sets ``additionalProperties`` to be false
+  when the default unknown fields are not explicitly set (:issue:`821`).
+  Thanks :user:`mwgamble` for the report and :user:`pieterocp` for the pr (:pr:`985`).
+
+
 6.8.2 (2025-05-12)
 ******************
 

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -258,6 +258,8 @@ class OpenAPIConverter(FieldConverterMixin):
             jsonschema["title"] = Meta.title
         if hasattr(Meta, "description"):
             jsonschema["description"] = Meta.description
+        if not hasattr(Meta, "unknown"):
+            jsonschema["additionalProperties"] = False
         if hasattr(Meta, "unknown") and Meta.unknown != marshmallow.EXCLUDE:
             jsonschema["additionalProperties"] = Meta.unknown == marshmallow.INCLUDE
 

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -143,6 +143,13 @@ class TestMarshmallowSchemaToModelDefinition:
         res = openapi.schema2jsonschema(UnknownRaiseSchema)
         assert res["additionalProperties"] is False
 
+    def test_unknown_value_unset_disallow(self, openapi):
+        class UnknownRaiseSchema(Schema):
+            first = fields.Str()
+
+        res = openapi.schema2jsonschema(UnknownRaiseSchema)
+        assert res["additionalProperties"] is False
+
     def test_unknown_values_allow(self, openapi):
         class UnknownIncludeSchema(Schema):
             class Meta:


### PR DESCRIPTION
Draft PR for pre-author feedback.

Off the back of #821

This should make it so that if we have this set, the spec we generate is a bit more like the actual implementation. (currently using an overlay to patch this in).

Will conduct a bit more testing before this is worth reviewing.